### PR TITLE
Update .npmignore to ship source map and code

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -25,10 +25,10 @@ debug*
 *.launch
 *.pid
 *.log
-*.js.map
-*.ts
 *.tgz
 !*.d.ts
+!index.ts
+!*.js.map
 .DS_Store
 .env
 .eslintrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-fields-list",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Extracts and returns list of fields requested from graphql resolver info object",
   "scripts": {
     "prepublish": "npm run build",


### PR DESCRIPTION
In the [published version of this package](https://unpkg.com/browse/graphql-fields-list@2.1.3/index.js), the index.js includes a source map comment :
```
//# sourceMappingURL=index.js.map
```
But this source map is not included, which can cause issues when trying to debug with source maps.

To fix this the package could either turn of source maps, thus removing the comment in the published version or as proposed include the source map and source in the published package.