### PR TITLE
Stop *.ts from publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -27,7 +27,7 @@ debug*
 *.log
 *.tgz
 !*.d.ts
-!index.ts
+*.ts
 !*.js.map
 .DS_Store
 .env


### PR DESCRIPTION
Hi, thank you for the great library.

Using TypeScript `4.3.2`, there are errors on this library because it includes `.ts` file. It should not be published. 
This behavior cannot be changed even if `tsconfig.json` set to the following:

```
{
  "compilerOptions": {
    "skipLibCheck": true, /* Skip type checking of declaration files. */
  },
  "exclude": [
    "node_modules"
  ]
```

![image](https://user-images.githubusercontent.com/10719495/122325626-e7a61580-cf65-11eb-841c-d7c9eec0999f.png)

Best regards