### PR TITLE
fix: Add package.json types declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "typescript": {
     "definitions": "index.d.ts"
   },
+  "types": "index.d.ts",
   "mocha": {
     "require": [
       "ts-node/register",


### PR DESCRIPTION
Added the "types" property in the package.json to include the type declarations: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package.

This solves the issue when running tsc and encountering the error related to https://github.com/Mikhus/graphql-fields-list/issues/43:

```
$ tsc --noEmit --project tsconfig.app.json
../../../node_modules/.pnpm/graphql-fields-list@2.3.0/node_modules/graphql-fields-list/index.ts(294,27): error TS2538: Type 'undefined' cannot be used as an index type.
../../../node_modules/.pnpm/graphql-fields-list@2.3.0/node_modules/graphql-fields-list/index.ts(295,26): error TS2538: Type 'undefined' cannot be used as an index type.
../../../node_modules/.pnpm/graphql-fields-list@2.3.0/node_modules/graphql-fields-list/index.ts(299,33): error TS2538: Type 'undefined' cannot be used as an index type.
../../../node_modules/.pnpm/graphql-fields-list@2.3.0/node_modules/graphql-fields-list/index.ts(318,9): error TS2322: Type 'SkipValue | undefined' is not assignable to type 'SkipValue'.
  Type 'undefined' is not assignable to type 'SkipValue'.
../../../node_modules/.pnpm/graphql-fields-list@2.3.0/node_modules/graphql-fields-list/index.ts(331,13): error TS2322: Type 'SkipValue | undefined' is not assignable to type 'SkipValue'.
  Type 'undefined' is not assignable to type 'SkipValue'.
../../../node_modules/.pnpm/graphql-fields-list@2.3.0/node_modules/graphql-fields-list/index.ts(390,17): error TS2345: Argument of type 'MapResultKey | undefined' is not assignable to parameter of type 'MapResultKey'.
  Type 'undefined' is not assignable to type 'MapResultKey'.
../../../node_modules/.pnpm/graphql-fields-list@2.3.0/node_modules/graphql-fields-list/index.ts(593,17): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.
```

